### PR TITLE
gcc5x changes default '1' to be int

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ IF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
    MESSAGE("")
    MESSAGE("cmake for GCC ")
    SET(PLATFORM_LINK_LIBRIES rt)
-   SET(CMAKE_CXX_FLAGS "-Wall -rdynamic -Wunused -std=c++11 -pthread -D_GLIBCXX_USE_NANOSLEEP")
+   SET(CMAKE_CXX_FLAGS "-Wall -rdynamic -Wunused -std=c++14 -pthread -D_GLIBCXX_USE_NANOSLEEP")
 ENDIF()
 
 
@@ -95,7 +95,7 @@ include_directories(test)
 include_directories(${PROJECT_SRC})
 file(GLOB TEST_SRC_FILES "test/*.cpp")
 
-SET(CMAKE_CXX_FLAGS "-Wall -Wno-sign-compare -rdynamic -Wunused -std=c++11 -pthread -D_GLIBCXX_USE_NANOSLEEP")
+SET(CMAKE_CXX_FLAGS "-Wall -Wno-sign-compare -rdynamic -Wunused -std=c++14 -pthread -D_GLIBCXX_USE_NANOSLEEP")
 add_executable(UnitTestRunner 3rdparty/test_main.cpp ${TEST_SRC_FILES} )
 target_link_libraries(UnitTestRunner ${LIBRARY_TO_BUILD} gtest_170_lib ${TEST_HELPER_LIBS})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ TARGET_LINK_LIBRARIES(${LIBRARY_TO_BUILD} ${TCMALLOC})
 
 # create the unit tests
 # =========================
-set(GTEST_DIR ${DIR_3RDPARTY}/gtest-1.7.0)
+set(GTEST_DIR ${DIR_3RDPARTY}/googletest-master/googletest)
 set(GTEST_INCLUDE_DIRECTORIES ${GTEST_DIR}/include ${GTEST_DIR} ${GTEST_DIR}/src)
 MESSAGE( "Attempt to build gtest. gtest directory: " ${GTEST_DIR})
 include_directories(${GTEST_INCLUDE_DIRECTORIES})
@@ -95,6 +95,8 @@ include_directories(test)
 include_directories(${PROJECT_SRC})
 file(GLOB TEST_SRC_FILES "test/*.cpp")
 
+SET(CMAKE_CXX_FLAGS "-Wall -Wno-sign-compare -rdynamic -Wunused -std=c++11 -pthread -D_GLIBCXX_USE_NANOSLEEP")
 add_executable(UnitTestRunner 3rdparty/test_main.cpp ${TEST_SRC_FILES} )
 target_link_libraries(UnitTestRunner ${LIBRARY_TO_BUILD} gtest_170_lib ${TEST_HELPER_LIBS})
+
 set_target_properties(${test} PROPERTIES COMPILE_FLAGS "-isystem -pthread ")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ TARGET_LINK_LIBRARIES(${LIBRARY_TO_BUILD} ${TCMALLOC})
 
 # create the unit tests
 # =========================
-set(GTEST_DIR ${DIR_3RDPARTY}/googletest-master/googletest)
+set(GTEST_DIR ${DIR_3RDPARTY}/gtest-1.7.0)
 set(GTEST_INCLUDE_DIRECTORIES ${GTEST_DIR}/include ${GTEST_DIR} ${GTEST_DIR}/src)
 MESSAGE( "Attempt to build gtest. gtest directory: " ${GTEST_DIR})
 include_directories(${GTEST_INCLUDE_DIRECTORIES})

--- a/packaging/FileIO.spec
+++ b/packaging/FileIO.spec
@@ -25,16 +25,16 @@ cd %{name}/
 PATH=/usr/local/probe/bin:$PATH
 rm -f  CMakeCache.txt
 cd 3rdparty
-unzip -u gtest-1.7.0.zip
+unzip -u gtest-master.zip
 cd ..
 
 
 if [ "%{buildtype}" == "-DUSE_DEBUG_COVERAGE=OFF" ]; then
    echo "buildtype: -DUSE_DEBUG_COVERAGE=OFF --> PRODUCTION"
-   /usr/local/probe/bin/cmake -DVERSION=%{version} -DCMAKE_CXX_COMPILER_ARG1:STRING=' -fPIC -Ofast -m64 -Wl,-rpath -Wl,. -Wl,-rpath -Wl,/usr/local/probe/lib -Wl,-rpath -Wl,/usr/local/probe/lib64 ' -DCMAKE_BUILD_TYPE:STRING=Release -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_CXX_COMPILER=/usr/local/probe/bin/g++
+   /usr/local/probe/bin/cmake -DVERSION=%{version} -DCMAKE_CXX_COMPILER_ARG1:STRING=' -std=c++14 -fPIC -Ofast -m64 -Wl,-rpath -Wl,. -Wl,-rpath -Wl,/usr/local/probe/lib -Wl,-rpath -Wl,/usr/local/probe/lib64 ' -DCMAKE_BUILD_TYPE:STRING=Release -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_CXX_COMPILER=/usr/local/probe/bin/g++
 elif [ "%{buildtype}" == "-DUSE_DEBUG_COVERAGE=ON" ]; then
    echo "buildtype: -DUSE_DEBUG_COVERAGE=ON";
-   /usr/local/probe/bin/cmake -DUSE_LR_DEBUG=ON -DVERSION=%{version} -DCMAKE_CXX_COMPILER_ARG1:STRING=' -Wall -Werror -g -gdwarf-2 -fprofile-arcs -ftest-coverage -O0 -fPIC -m64 -Wl,-rpath -Wl,. -Wl,-rpath -Wl,/usr/local/probe/lib -Wl,-rpath -Wl,/usr/local/probe/lib64 ' -DCMAKE_CXX_COMPILER=/usr/local/probe/bin/g++
+   /usr/local/probe/bin/cmake -DUSE_LR_DEBUG=ON -DVERSION=%{version} -DCMAKE_CXX_COMPILER_ARG1:STRING=' -std=c++14 -Wall -Werror -g -gdwarf-2 -fprofile-arcs -ftest-coverage -O0 -fPIC -m64 -Wl,-rpath -Wl,. -Wl,-rpath -Wl,/usr/local/probe/lib -Wl,-rpath -Wl,/usr/local/probe/lib64 ' -DCMAKE_CXX_COMPILER=/usr/local/probe/bin/g++
 else
    echo "unknown buildtype %{buildtype}"
    exit 1

--- a/packaging/FileIO.spec
+++ b/packaging/FileIO.spec
@@ -25,7 +25,7 @@ cd %{name}/
 PATH=/usr/local/probe/bin:$PATH
 rm -f  CMakeCache.txt
 cd 3rdparty
-unzip -u gtest-master.zip
+unzip -u gtest-1.7.0.zip
 cd ..
 
 

--- a/src/FileIO.cpp
+++ b/src/FileIO.cpp
@@ -21,6 +21,7 @@
 #include <cerrno>
 #include <cstring>
 #include <memory>
+#include <string>
 
 namespace FileIO {
    std::mutex mPermissionsMutex;
@@ -397,7 +398,7 @@ namespace FileIO {
             int removed = rmdir(directory.c_str());
             if (0 != removed) {
                success = false;
-               error << "\n" << directory << error << ", error: " << std::strerror(errno);               
+               error << "\n" << directory << ", error: " << std::strerror(errno);               
             }
          }
       }


### PR DESCRIPTION
gcc5x makes by default the '1' in EXPECT_EQ(value, 1) to be int which causes signed/unsigned warnings for unit tests