### PR TITLE
Corrected the license to be LogRhythm MIT and adjusted the README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-The MIT License (MIT)
+MIT License
 
-Copyright (c) 2014 Robert Weber
+Copyright (c) 2014 LogRhythm
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,4 +1,18 @@
 FileIO
 ======
 
-A generic C++ file IO class
+Is a collection of file access and directory traversal utilities that was written to be a fast, easy to use and non-exception throwing library. 
+
+The major areas it deals with are:
+
+_Directory  traversal and file access actions_:  
+The DirectoryReader and FileSystemWalker are efficient for traversing directory structures and accessing files with ad-hoc actions on those files.  The code was written to be efficient, fast and easy to use. 
+
+Errors are handled through return types and embedded error messages with the result.   In an error-prone scenario the FileIO execution is significantly faster than than solutins that utilizes exceptions. 
+
+
+**File Access**  
+The file access code was written to avoid rewriting boiler plate code that is easy to get wrong. It covers areas such as file reading and writing, changing file ownership, deleting files and directories and moving of files. Many of these functionalities involve low-level C or C++ API that are awkward to use and prone to have bugs. 
+
+The **API** is accessible in the [[src]](https://github.com/LogRhythm/FileIO/tree/master/src) directory. Please read the header files together with [[test cases and example usage]](https://github.com/LogRhythm/FileIO/tree/master/test).
+

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Is a collection of file access and directory traversal utilities that was writte
 
 The major areas it deals with are:
 
-_Directory  traversal and file access actions_:  
-The DirectoryReader and FileSystemWalker are efficient for traversing directory structures and accessing files with ad-hoc actions on those files.  The code was written to be efficient, fast and easy to use. 
+*_Directory  traversal and file access actions_*:  
+The _DirectoryReader_ and _FileSystemWalker_ are efficient for traversing directory structures and accessing files with ad-hoc actions on those files.  The code was written to be efficient, fast and easy to use. 
 
 Errors are handled through return types and embedded error messages with the result.   In an error-prone scenario the FileIO execution is significantly faster than than solutins that utilizes exceptions. 
 

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ Is a collection of file access and directory traversal utilities that was writte
 
 The major areas it deals with are:
 
-*_Directory  traversal and file access actions_*:  
-The _DirectoryReader_ and _FileSystemWalker_ are efficient for traversing directory structures and accessing files with ad-hoc actions on those files.  The code was written to be efficient, fast and easy to use. 
+*_Directory traversal and file access actions_*: 
+The _DirectoryReader_ and _FileSystemWalker_ are efficient for traversing directory structures and accessing files with ad-hoc actions on those files. The code was written to be efficient, fast and easy to use. 
 
-Errors are handled through return types and embedded error messages with the result.   In an error-prone scenario the FileIO execution is significantly faster than than solutions that utilizes exceptions. 
+Errors are handled through return types and embedded error messages with the [[result]](https://github.com/LogRhythm/FileIO/blob/master/src/Result.h).  In an error-prone scenario the FileIO execution is significantly faster than solutions that utilize exceptions. 
 
 
-**File Access**  
-The file access code was written to avoid rewriting boiler plate code that is easy to get wrong. It covers areas such as file reading and writing, changing file ownership, deleting files and directories and moving of files. Many of these functionalities involve low-level C or C++ API that are awkward to use and prone to have bugs. 
+**File Access** 
+The file access code was written to avoid rewriting boiler plate code that is easy to get wrong. It covers areas such as file reading and writing, changing file ownership, deleting files and directories and moving of files. Many of these functionalities involve low-level C or C++ APIs that are awkward to use and prone to having bugs. 
 
 The **API** is accessible in the [[src]](https://github.com/LogRhythm/FileIO/tree/master/src) directory. Please read the header files together with [[test cases and example usage]](https://github.com/LogRhythm/FileIO/tree/master/test).
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The major areas it deals with are:
 *_Directory  traversal and file access actions_*:  
 The _DirectoryReader_ and _FileSystemWalker_ are efficient for traversing directory structures and accessing files with ad-hoc actions on those files.  The code was written to be efficient, fast and easy to use. 
 
-Errors are handled through return types and embedded error messages with the result.   In an error-prone scenario the FileIO execution is significantly faster than than solutins that utilizes exceptions. 
+Errors are handled through return types and embedded error messages with the result.   In an error-prone scenario the FileIO execution is significantly faster than than solutions that utilizes exceptions. 
 
 
 **File Access**  


### PR DESCRIPTION
This pull request corrects the LogRhythm LICENSE and improves the Readme.

The README can best be read at: https://github.com/KjellKod/FileIO/blob/LogRhythm_OpenSource_Compliance/README.md